### PR TITLE
Pin Travis Max OS X version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ matrix:
  - os: osx
    env: DIST="sdist bdist_wheel"
    language: generic
+   osx_image: xcode9.3beta
 
 env:
  global:


### PR DESCRIPTION
Default Travis Mac OS X version causes binary to abort with trap 6.