### PR TITLE
Fix build on MacOS 11.1

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -44,15 +44,19 @@ SMCFLAGS = -DHAVE_VA_COPY -DVA_COPY=__va_copy
 
 ifeq ($(OS_ARCH),Darwin)
   PREFIX = /usr/local
-  MAC_MINOR_VERSION := $(shell sw_vers -productVersion | cut -d. -f2)
-  MAC_GT_5 := $(shell [ $(MAC_MINOR_VERSION) -le 5 ] && echo false)
+  MAC_MAJOR_VERSION := $(shell sw_vers -productVersion | cut -d. -f1)
+  MAC_GT_OS11 := $(shell [ $(MAC_MAJOR_VERSION) -le 10 ] && echo false)
   SO_SUFFIX = dylib
   LIBRARY = $(LIBRARY_NAME).$(LIB_VER).$(SO_SUFFIX)
   MKSHLIB = $(CC) -dynamiclib -framework System
   LIB_OPTS = -install_name $(PREFIX)/lib/$(notdir $@)
   SHFLAGS =
-  ifeq ($(MAC_GT_5),false)
-    SMCFLAGS =
+  ifeq ($(MAC_GT_OS11),false)
+    MAC_MINOR_VERSION := $(shell sw_vers -productVersion | cut -d. -f2)
+    MAC_GT_10_5 := $(shell [ $(MAC_MINOR_VERSION) -le 5 ] && echo false)
+    ifeq ($(MAC_GT_10_5),false)
+      SMCFLAGS =
+    endif
   endif
 endif
 


### PR DESCRIPTION
The Makefile has some code that disables some flags related to varargs handling when building on pre-10.5 OS/X.  Unfortunately since it only uses the ".5" part to decide if it's running on an old mac version this old code came back to life on MacOS 11.1!