### PR TITLE
build: Don't quote $(MAKE)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -80,11 +80,11 @@ MAN_PREFIX = $(PREFIX)/share/man
 all: testpactester
 
 jsapi_buildstamp: spidermonkey/js/src
-	cd spidermonkey && SMCFLAGS="$(SHFLAGS) $(SMCFLAGS)" "$(MAKE)" jsapi
+	cd spidermonkey && SMCFLAGS="$(SHFLAGS) $(SMCFLAGS)" $(MAKE) jsapi
 	touch jsapi_buildstamp
 
 libjs.a: spidermonkey/js/src
-	cd spidermonkey && SMCFLAGS="$(SHFLAGS) $(SMCFLAGS)" "$(MAKE)" jslib
+	cd spidermonkey && SMCFLAGS="$(SHFLAGS) $(SMCFLAGS)" $(MAKE) jslib
 
 pacparser.o: pacparser.c pac_utils.h pacparser.h jsapi_buildstamp
 	$(CC) $(CFLAGS) $(SHFLAGS) -c pacparser.c -o pacparser.o
@@ -137,4 +137,4 @@ install-pymod: pymod
 clean:
 	rm -f $(LIBRARY_LINK) $(LIBRARY) libjs.a pacparser.o pactester pymod/pacparser_o_buildstamp jsapi_buildstamp
 	cd pymod && $(PYTHON) setup.py clean --all
-	cd spidermonkey && "$(MAKE)" clean
+	cd spidermonkey && $(MAKE) clean

--- a/src/spidermonkey/Makefile
+++ b/src/spidermonkey/Makefile
@@ -34,7 +34,7 @@ jslib: js-buildstamp
 
 js-buildstamp:
 	mkdir -p js/src/$(OBJDIR)
-	CFLAGS="$(SMCFLAGS)" "$(MAKE)" -C js/src -f Makefile.ref libjs.a
+	CFLAGS="$(SMCFLAGS)" $(MAKE) -C js/src -f Makefile.ref libjs.a
 	find js/src -name "jsautocfg.h" -exec cp {} js/src \;
 	touch js-buildstamp
 


### PR DESCRIPTION
The `$(MAKE)` variable may contain `make(1)` arguments in addition to the `make(1)` command.

Downstream issue: https://bugs.gentoo.org/793425

Example:
```
$ export MAKE='make LIBTOOL=rdlibtool'

$ make -C src/spidermonkey/
make: Entering directory '/tmp/pacparser/src/spidermonkey'
mkdir -p js/src/Linux_All_DBG.OBJ
CFLAGS="" "make LIBTOOL=rdlibtool" -C js/src -f Makefile.ref libjs.a
/bin/sh: make LIBTOOL=rdlibtool: command not found
make: *** [Makefile:37: js-buildstamp] Error 127
make: Leaving directory '/tmp/pacparser/src/spidermonkey
```
Note that while pacparser does not use libtool in an environment that uses slibtool (Instead of GNU libtool) this issue is exposed. I am sure there are other cases where this can happen too.