### PR TITLE
Fix very minor Makefile issue in spidermonkey `clean` target (#109)

### DIFF
--- a/src/spidermonkey/Makefile
+++ b/src/spidermonkey/Makefile
@@ -21,10 +21,8 @@
 # Include config.mk to get the variable $(OBJDIR).
 # We need to create $(OBJDIR) first to be able to build libjs.a alone.
 
-ifneq ($(MAKECMDGOALS),clean)
-  DEPTH = js/src
-  include js/src/config.mk
-endif
+DEPTH = js/src
+include js/src/config.mk
 
 jsapi: js-buildstamp
 
@@ -40,4 +38,4 @@ js-buildstamp:
 
 clean:
 	rm -rf js-buildstamp
-	rm js/src/*.o
+	rm -rf js/src/$(OBJDIR)


### PR DESCRIPTION
This fixes #109 and while I didn't test it across different platforms, I did confirm there is no breakage with the build or clean targets on a Linux system with a glibc+gcc toolchain

If you don't think this is really necessary please feel free to close it

Thanks!