### PR TITLE
Windows build: Use git version.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,6 @@ name: Build Pacparser
 
 on:
   push:
-    branches: [ master ]
   pull_request:
 
 jobs:

--- a/src/Makefile.win32
+++ b/src/Makefile.win32
@@ -36,6 +36,8 @@ RM = rm -rf
 CP = cp -f
 endif
 
+VERSION ?= $(shell git describe --always --tags --candidate=100)
+
 LIB_VER=1
 CFLAGS=-g -DXP_WIN -DWINVER=0x0501 -DVERSION=$(VERSION) -Ispidermonkey/js/src -Wall
 CC=gcc


### PR DESCRIPTION
Use git to determine pacparser version if not specified on the command line.