### PR TITLE
tests: Fix python path in runtests.py

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -26,10 +26,20 @@ import os
 import sys
 
 def runtests(pacfile, testdata, tests_dir):
-  py_ver = '.'.join([str(x) for x in sys.version_info[0:2]])
+  ver = '.'.join([str(x) for x in sys.version_info[0:2]])
+  py_ver = [ver, ver.replace('.', '')]
   try:
-    pacparser_module_path = glob.glob(os.path.join(
-      tests_dir, '..', 'src', 'pymod', 'build', 'lib*%s' % py_ver))[0]
+    module_path = glob.glob(os.path.join(
+      tests_dir, '..', 'src', 'pymod', 'build', 'lib*'))
+    module_found = False
+    for module in module_path:
+      for version in py_ver:
+        if module.endswith(version):
+          module_found = True
+          break
+      if module_found:
+        pacparser_module_path = module
+        break
   except Exception:
     raise Exception('Tests failed. Could not determine pacparser path.')
   if 'DEBUG' in os.environ: print('Pacparser module path: %s' %


### PR DESCRIPTION
Note: Please review that I am solving this correctly, thanks!

In Gentoo the `runtests.py` script fails when it fails to determine the pacparser path.

This happens because `py_ver` expands to `3.9` when the expected directory ends in `39`. This can be solved by replacing any periods in the string.
```
python ../tests/runtests.py
Traceback (most recent call last):
  File "/tmp/pacparser/src/../tests/runtests.py", line 31, in runtests
    pacparser_module_path = glob.glob(os.path.join(
IndexError: list index out of range

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/tmp/pacparser/src/../tests/runtests.py", line 81, in <module>
    main()
  File "/tmp/pacparser/src/../tests/runtests.py", line 78, in main
    runtests(pacfile, testdata, tests_dir)
  File "/tmp/pacparser/src/../tests/runtests.py", line 34, in runtests
    raise Exception('Tests failed. Could not determine pacparser path.')
Exception: Tests failed. Could not determine pacparser path.
```
Full build log: [pacparser.pymod.log](https://github.com/manugarg/pacparser/files/8692618/pacparser.pymod.log)

Reproduction: `make -C src pymod`
