### PR TITLE
Improve read_file_into_str safety

### DIFF
--- a/src/pacparser.c
+++ b/src/pacparser.c
@@ -80,15 +80,16 @@ _debug(void) {
 static char *                      // File content in string or NULL if failed.
 read_file_into_str(const char *filename)
 {
-  char *str;
-  int file_size;
-  FILE *fptr;
-  int records_read;
-  if (!(fptr = fopen(filename, "r"))) goto error1;
-  if ((fseek(fptr, 0L, SEEK_END) != 0)) goto error2;
-  if (!(file_size=ftell(fptr))) goto error2;
-  if ((fseek(fptr, 0L, SEEK_SET) != 0)) goto error2;
-  if (!(str = (char*) malloc(file_size+1))) goto error2;
+  FILE *fptr = fopen(filename, "r");
+  if (fptr == NULL) return NULL;
+
+  if (fseek(fptr, 0L, SEEK_END) != 0) goto error2;
+  long file_size=ftell(fptr);
+  if (file_size == -1) goto error2;
+  if (fseek(fptr, 0L, SEEK_SET) != 0) goto error2;
+
+  char *str = (char*) malloc(file_size+1);
+  if (str == NULL) goto error2;
 
   // Read the file into the string
   size_t bytes_read = fread(str, 1, file_size, fptr);
@@ -102,7 +103,6 @@ read_file_into_str(const char *filename)
   return str;
 error2:
   fclose(fptr);
-error1:
   return NULL;
 }
 

--- a/src/pacparser.c
+++ b/src/pacparser.c
@@ -98,6 +98,9 @@ read_file_into_str(const char *filename)
     goto error2;
   }
  
+  // This check should not be needed but adding this satisfies
+  // sonarlint static analysis, otherwise it complains about tainted
+  // index.
   if (bytes_read >= 0 && bytes_read < file_size+1) {
     str[bytes_read] = '\0';
   }

--- a/src/pacparser.c
+++ b/src/pacparser.c
@@ -89,11 +89,15 @@ read_file_into_str(const char *filename)
   if (!(file_size=ftell(fptr))) goto error2;
   if ((fseek(fptr, 0L, SEEK_SET) != 0)) goto error2;
   if (!(str = (char*) malloc(file_size+1))) goto error2;
-  if (!(records_read=fread(str, 1, file_size, fptr))) {
+
+  // Read the file into the string
+  size_t bytes_read = fread(str, 1, file_size, fptr);
+  if (bytes_read != file_size) {
     free(str);
     goto error2;
   }
-  str[records_read] = '\0';
+
+  str[file_size] = '\0';
   fclose(fptr);
   return str;
 error2:

--- a/src/pacparser.c
+++ b/src/pacparser.c
@@ -97,8 +97,10 @@ read_file_into_str(const char *filename)
     free(str);
     goto error2;
   }
-
-  str[file_size] = '\0';
+ 
+  if (bytes_read >= 0 && bytes_read < file_size+1) {
+    str[bytes_read] = '\0';
+  }
   fclose(fptr);
   return str;
 error2:


### PR DESCRIPTION
Make read_file_into_str safer by making sure bytes_read are equal to file_size before adding the null terminator at the end.