### PR TITLE
Update sonar.yml permissions

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -5,8 +5,7 @@ on:
       - master
   pull_request:
     types: [opened, synchronize, reopened]
-permissions:
-  contents: read
+permissions: read-all
 jobs:
   build:
     name: Analyze

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -5,6 +5,8 @@ on:
       - master
   pull_request:
     types: [opened, synchronize, reopened]
+permissions:
+  contents: read
 jobs:
   build:
     name: Analyze


### PR DESCRIPTION
I've noticed that the sonar.yml workflow was not with top level permission defined. 

Looking into https://github.com/SonarSource/sonarcloud-github-c-cpp it was not clear which permissions should be granted and, considering that a SONAR_TOKEN is required I wasn't able to test. I'll wait for the CI to run here on the PR to see if it will be enough.

Related to https://github.com/manugarg/pacparser/issues/145 and https://github.com/manugarg/pacparser/pull/146
