### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://github.com/manugarg/pacparser/actions/workflows/build.yml/badge.svg)](https://github.com/manugarg/pacparser/actions/workflows/build.yml)
 [![PyPI version](https://badge.fury.io/py/pacparser.svg)](https://badge.fury.io/py/pacparser)
+[![Packaging status](https://repology.org/badge/tiny-repos/pacparser.svg)](https://repology.org/project/pacparser/versions)
 
 # [Pacparser](http://pacparser.manugarg.com)
 ***[pacparser.manugarg.com](http://pacparser.manugarg.com)***
@@ -95,7 +96,7 @@ PROXY proxy1.manugarg.com:3128; PROXY proxy2.manugarg.com:3128; DIRECT
 
 #### Platforms
 pacparser has been tested to work on Linux (all architectures supported by
-Debian), Mac OS X and Win32 systems.
+Debian), FreeBSD, Mac OS X and Win32 systems.
 
 #### Homepage
 http://pacparser.manugarg.com


### PR DESCRIPTION
Update documentation:

* Add FreeBSD to the list of tested versions
* Add a nice repology badge to show the packaging status of this project

After merging https://github.com/manugarg/pacparser/pull/171, I've added an official FreeBSD [port](https://cgit.freebsd.org/ports/tree/www/pacparser) to the repository. I've tested the python bindings as well as the pactester binary. Here is how a FreeBSD user can install pacparser.

Via package:

```sh
pkg install pacparser
```

Building via ports:

```sh
cd /usr/ports/www/pacparser
make install clean
```

I had to reference the latest commit hash for the version since earlier releases didn't have FreeBSD support. Please consider tagging `v1.4.3`.

# Tests

pactester:

```sh
# uname -a
FreeBSD portjail.local 13.2-RELEASE-p1 FreeBSD 13.2-RELEASE-p1 GENERIC amd64
# gmake testpactester
echo "Running tests for pactester."
Running tests for pactester.
NO_INTERNET= ../tests/runtests.sh
All tests were successful.
```

Python bindings:

```sh
# python ../tests/runtests.py 
Build dir: %s /usr/ports/www/pacparser/work/pacparser-e29c1a3/src/../tests/../src/pymod/build
['lib.freebsd-13.2-RELEASE-p1-amd64-cpython-39', 'temp.freebsd-13.2-RELEASE-p1-amd64-cpython-39']
All tests were successful.
```