### PR TITLE
[makefile] Use va_copy everywhere instead of __va_copy

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -47,6 +47,10 @@ LIB_OPTS = -Wl,-soname=$(LIBRARY) -Wl,-exclude-libs=libjs.a
 SHFLAGS = -fPIC
 SMCFLAGS = -DHAVE_VA_COPY -DVA_COPY=__va_copy
 
+ifeq ($(shell test -f /etc/alpine-release && echo yes),yes)
+    SMCFLAGS = -DHAVE_VA_COPY -DVA_COPY=va_copy
+endif
+
 ifeq ($(OS_ARCH),FreeBSD)
 	PREFIX ?= /usr/local
 endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -45,11 +45,7 @@ LIBRARY = $(LIBRARY_NAME).$(SO_SUFFIX).$(LIB_VER)
 MKSHLIB = $(CC) -shared
 LIB_OPTS = -Wl,-soname=$(LIBRARY) -Wl,-exclude-libs=libjs.a
 SHFLAGS = -fPIC
-SMCFLAGS = -DHAVE_VA_COPY -DVA_COPY=__va_copy
-
-ifeq ($(shell test -f /etc/alpine-release && echo yes),yes)
-    SMCFLAGS = -DHAVE_VA_COPY -DVA_COPY=va_copy
-endif
+SMCFLAGS = -DHAVE_VA_COPY -DVA_COPY=va_copy
 
 ifeq ($(OS_ARCH),FreeBSD)
 	PREFIX ?= /usr/local


### PR DESCRIPTION
On Alpine Linux use va_copy instead of __va_copy. See https://github.com/manugarg/pacparser/issues/77 for more details.