### PR TITLE
Add Python 3.13 to build matrix and drop macos-13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,14 +25,12 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         include:
           - os: ubuntu-latest
             os_suffix: "ubuntu-x86_64"
           - os: macos-latest
             os_suffix: "macos-arm64"
-          - os: macos-13
-            os_suffix: "macos-x86_64"
           - os: windows-latest
             os_suffix: "windows-x86_64"
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
- Github is dropping macos-13 support.
- This means we'll not have x86_64 binaries for Mac anymore.