### PR TITLE
Add alert() and console.log() for PAC script debugging

### DIFF
--- a/src/pacparser.c
+++ b/src/pacparser.c
@@ -217,17 +217,17 @@ dns_resolve_ex(JSContext *ctx, JSValueConst UNUSED(this_val), int UNUSED(argc), 
   return JS_NewString(ctx, ipaddr);
 }
 
-// Shared helper for alert() and console.log(): concatenates all arguments with
-// spaces and prints them via the error printer (stderr by default). Intended
-// purely for debugging PAC scripts; production PAC files are not expected to
-// call these.
+// Prints space-separated args via the error printer (stderr by default).
 static JSValue
 js_log_print(JSContext *ctx, int argc, JSValueConst *argv, const char *prefix)
 {
   print_error("%s:", prefix);
   for (int i = 0; i < argc; i++) {
     const char *s = JS_ToCString(ctx, argv[i]);
-    if (!s) return JS_EXCEPTION;
+    if (!s) {
+      print_error("\n");
+      return JS_EXCEPTION;
+    }
     print_error(" %s", s);
     JS_FreeCString(ctx, s);
   }
@@ -235,14 +235,12 @@ js_log_print(JSContext *ctx, int argc, JSValueConst *argv, const char *prefix)
   return JS_UNDEFINED;
 }
 
-// alert(msg) in JS context; routes message to the error printer.
 static JSValue
 pac_alert(JSContext *ctx, JSValueConst UNUSED(this_val), int argc, JSValueConst *argv)
 {
   return js_log_print(ctx, argc, argv, "ALERT");
 }
 
-// console.log(...args) in JS context; routes message to the error printer.
 static JSValue
 pac_console_log(JSContext *ctx, JSValueConst UNUSED(this_val), int argc, JSValueConst *argv)
 {
@@ -350,8 +348,6 @@ pacparser_init()
   JS_SetPropertyStr(ctx, global, "myIpAddressEx",
     JS_NewCFunction(ctx, my_ip_ex, "myIpAddressEx", 0));
 
-  // Debug logging helpers for PAC scripts. Output goes through the error
-  // printer (stderr by default).
   JS_SetPropertyStr(ctx, global, "alert",
     JS_NewCFunction(ctx, pac_alert, "alert", 1));
   JSValue console = JS_NewObject(ctx);

--- a/src/pacparser.c
+++ b/src/pacparser.c
@@ -217,6 +217,38 @@ dns_resolve_ex(JSContext *ctx, JSValueConst UNUSED(this_val), int UNUSED(argc), 
   return JS_NewString(ctx, ipaddr);
 }
 
+// Shared helper for alert() and console.log(): concatenates all arguments with
+// spaces and prints them via the error printer (stderr by default). Intended
+// purely for debugging PAC scripts; production PAC files are not expected to
+// call these.
+static JSValue
+js_log_print(JSContext *ctx, int argc, JSValueConst *argv, const char *prefix)
+{
+  print_error("%s:", prefix);
+  for (int i = 0; i < argc; i++) {
+    const char *s = JS_ToCString(ctx, argv[i]);
+    if (!s) return JS_EXCEPTION;
+    print_error(" %s", s);
+    JS_FreeCString(ctx, s);
+  }
+  print_error("\n");
+  return JS_UNDEFINED;
+}
+
+// alert(msg) in JS context; routes message to the error printer.
+static JSValue
+pac_alert(JSContext *ctx, JSValueConst UNUSED(this_val), int argc, JSValueConst *argv)
+{
+  return js_log_print(ctx, argc, argv, "ALERT");
+}
+
+// console.log(...args) in JS context; routes message to the error printer.
+static JSValue
+pac_console_log(JSContext *ctx, JSValueConst UNUSED(this_val), int argc, JSValueConst *argv)
+{
+  return js_log_print(ctx, argc, argv, "LOG");
+}
+
 // myIpAddress in JS context; not available in core JavaScript.
 // returns 127.0.0.1 if not able to determine local ip.
 static JSValue
@@ -317,6 +349,15 @@ pacparser_init()
     JS_NewCFunction(ctx, dns_resolve_ex, "dnsResolveEx", 1));
   JS_SetPropertyStr(ctx, global, "myIpAddressEx",
     JS_NewCFunction(ctx, my_ip_ex, "myIpAddressEx", 0));
+
+  // Debug logging helpers for PAC scripts. Output goes through the error
+  // printer (stderr by default).
+  JS_SetPropertyStr(ctx, global, "alert",
+    JS_NewCFunction(ctx, pac_alert, "alert", 1));
+  JSValue console = JS_NewObject(ctx);
+  JS_SetPropertyStr(ctx, console, "log",
+    JS_NewCFunction(ctx, pac_console_log, "log", 1));
+  JS_SetPropertyStr(ctx, global, "console", console);
 
   // Evaluate pacUtils. Utility functions required to parse pac files.
   JSValue result = JS_Eval(ctx, pacUtils, strlen(pacUtils), "pac_utils",

--- a/tests/logging.pac
+++ b/tests/logging.pac
@@ -1,0 +1,7 @@
+// Test PAC file exercising alert() and console.log() debug helpers.
+function FindProxyForURL(url, host) {
+  alert("checking", host);
+  console.log("url:", url);
+  console.log("single arg");
+  return "DIRECT";
+}

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -24,6 +24,7 @@ import getopt
 import glob
 import os
 import sys
+import tempfile
 
 def module_path(tests_dir):
   py_ver = '*'.join([str(x) for x in sys.version_info[0:2]])
@@ -75,6 +76,34 @@ def runtests(pacfile, testdata, tests_dir):
     pacparser.cleanup()
     if result != expected_result:
       raise Exception('Tests failed. Got "%s", expected "%s"' % (result, expected_result))
+
+  # Logging test: alert() / console.log() should emit to the C library's
+  # stderr. The extension writes directly via vfprintf, so redirect at the
+  # file-descriptor level rather than via sys.stderr.
+  logging_pac = os.path.join(tests_dir, 'logging.pac')
+  expected_stderr = ('ALERT: checking example.com\n'
+                     'LOG: url: http://example.com/\n'
+                     'LOG: single arg\n')
+  with tempfile.TemporaryFile(mode='w+') as tmp:
+    saved_fd = os.dup(2)
+    os.dup2(tmp.fileno(), 2)
+    try:
+      pacparser.init()
+      pacparser.parse_pac_file(logging_pac)
+      proxy = pacparser.find_proxy('http://example.com/', 'example.com')
+      pacparser.cleanup()
+    finally:
+      sys.stderr.flush()
+      os.dup2(saved_fd, 2)
+      os.close(saved_fd)
+    tmp.seek(0)
+    actual_stderr = tmp.read()
+  if proxy != 'DIRECT':
+    raise Exception('Logging test failed: proxy was "%s", expected "DIRECT"' % proxy)
+  if actual_stderr != expected_stderr:
+    raise Exception('Logging test failed: stderr mismatch\nExpected:\n%s\nGot:\n%s' %
+                    (expected_stderr, actual_stderr))
+
   print('All tests were successful.')
 
 

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -55,4 +55,28 @@ while read line
     fi
   done < $testdata
 
+
+# Logging tests: verify alert() / console.log() output lands on stderr with
+# the expected prefixes, and that the proxy result on stdout is unaffected.
+logging_pac=$script_dir/logging.pac
+logging_stderr=$(mktemp)
+logging_stdout=$($pactester -p $logging_pac -u http://example.com/ -h example.com 2>$logging_stderr)
+if [ "$logging_stdout" != "DIRECT" ]; then
+  echo "Logging test failed: stdout was \"$logging_stdout\", expected \"DIRECT\""
+  cat $logging_stderr
+  rm -f $logging_stderr
+  exit 1
+fi
+expected_stderr=$'ALERT: checking example.com\nLOG: url: http://example.com/\nLOG: single arg'
+actual_stderr=$(cat $logging_stderr)
+rm -f $logging_stderr
+if [ "$actual_stderr" != "$expected_stderr" ]; then
+  echo "Logging test failed: stderr mismatch"
+  echo "Expected:"
+  echo "$expected_stderr"
+  echo "Got:"
+  echo "$actual_stderr"
+  exit 1
+fi
+
 echo "All tests were successful."


### PR DESCRIPTION
## Summary
- Expose `alert(msg)` and `console.log(...args)` in the PAC JavaScript context so authors can debug large PAC files.
- Output is routed through the existing error printer (stderr by default, overridable via `pacparser_set_error_printer`), so `pactester`'s stdout proxy result stays unaffected.
- Messages are prefixed with `ALERT:` / `LOG:`.

Fixes #32.

## Test plan
- [x] `NO_INTERNET=1 make -C src` passes (existing testdata + new end-to-end logging test in `tests/runtests.sh`).
- [x] Manually verified with `pactester` that logs go to stderr and proxy result stays on stdout.
- [x] Intentionally mutated `tests/logging.pac` to confirm the new check fails loudly and exits non-zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)