### PR TITLE
Build .deb and .rpm packages for Linux releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,6 +119,24 @@ jobs:
           name: pacparser-dist-${{ matrix.os }}
           path: src/dist
 
+      - name: Build deb and rpm packages (ubuntu)
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y rpm
+          sudo gem install --no-document fpm
+          make -C src pkg
+          ls src/*.deb src/*.rpm
+
+      - name: Upload packages (ubuntu)
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: pacparser-dist-packages
+          path: |
+            src/*.deb
+            src/*.rpm
+
   build-release-binaries:
     needs: build
     runs-on: ubuntu-latest
@@ -132,6 +150,7 @@ jobs:
         run: |
           ls -R .
           mv pacparser-dist-*/*.zip .
+          mv pacparser-dist-packages/*.deb pacparser-dist-packages/*.rpm .
           file=$(ls pacparser-*-ubuntu*.zip)
           name=${file/ubuntu/windows}
           name=${name/.zip/}
@@ -142,7 +161,10 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: pacparser-release-binaries
-          path: pacparser-*.zip
+          path: |
+            pacparser-*.zip
+            *.deb
+            *.rpm
 
   python-module-build:
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@
 tools/packages
 *.dmg
 *.pkg
+*.deb
+*.rpm
+src/pkgroot
 
 # Other build files
 *buildstamp

--- a/INSTALL
+++ b/INSTALL
@@ -4,9 +4,15 @@ For Python module, it's recommended to use "pip" for the installation:
 
 For other pre-built binaries, download them from:
   https://github.com/manugarg/pacparser/releases
-  
+
 You can also download the latest binaries from the Github actions artifacts:
   https://github.com/manugarg/pacparser/actions
+
+On Debian/Ubuntu (.deb) and RHEL/Fedora (.rpm), download the package for your
+distro from the releases page above and install it with your package manager
+(this installs libpacparser, pactester, headers, and man pages):
+  sudo apt install ./pacparser_<version>_amd64.deb     # Debian/Ubuntu
+  sudo dnf install ./pacparser-<version>.x86_64.rpm     # RHEL/Fedora
 
 
 Compile From Source:

--- a/src/Makefile
+++ b/src/Makefile
@@ -142,6 +142,27 @@ dist: all
 	PREFIX= $(MAKE) install DESTDIR=$${bindir}; \
 	zip -r $${bindir}.zip $${bindir}/.
 
+# Build .deb and .rpm packages from a staged install tree under /usr.
+# Requires fpm (https://github.com/jordansissel/fpm); the rpm output also
+# needs rpmbuild to be available.
+PKG_NAME = pacparser
+
+pkg: all
+	rm -rf pkgroot
+	PREFIX=/usr $(MAKE) install DESTDIR=pkgroot
+	pkgver=$$(echo "$(VERSION)" | sed -e 's/^v//' -e 's/-/./g'); \
+	for type in deb rpm; do \
+	  fpm -s dir -t $$type --force \
+	    -n $(PKG_NAME) -v $$pkgver \
+	    --license "LGPL-3.0" \
+	    --description "C library and CLI (pactester) to parse proxy auto-config (PAC) files" \
+	    --url "https://github.com/manugarg/pacparser" \
+	    --maintainer "Manu Garg <manugarg@gmail.com>" \
+	    --after-install pkg/ldconfig.sh \
+	    --after-remove pkg/ldconfig.sh \
+	    -C pkgroot usr; \
+	done
+
 # Targets to build python module
 pymod: pacparser.o pacparser.h quickjs/libquickjs.a
 	cd pymod && ARCHFLAGS="" $(PYTHON) setup.py build

--- a/src/pkg/ldconfig.sh
+++ b/src/pkg/ldconfig.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Refresh the dynamic linker cache after libpacparser is installed or removed.
+ldconfig


### PR DESCRIPTION
Closes #241.

## Summary
- Add a `pkg` Makefile target that stages an FHS install tree and runs `fpm` to emit both `.deb` and `.rpm` (ldconfig wired in via post-install/remove hooks).
- Build and publish the packages from the CI release flow, alongside the existing zips.
- Document installing from `.deb`/`.rpm` in `INSTALL`.

## Test plan
- Verified the staged `/usr` tree (paths + perms) produced by the install step.
- Verified the `pkg` target's deb/rpm fpm invocations via a stub (incl. version sanitizing `v1.5.1-3-gxxxx` → `1.5.1.3.gxxxx`).
- Actual `.deb`/`.rpm` generation runs in CI (fpm/rpmbuild not available locally).