### PR TITLE
Document SonarCloud token rotation

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,3 +1,14 @@
+# SonarCloud analysis. Auth uses the SONAR_TOKEN repo secret, which expires
+# (SonarCloud caps token lifetime at ~1 year). Because this repo changes
+# infrequently, the token often expires unnoticed and the next push/PR fails
+# here. C/C++ requires this token-based CI analysis, so the token can't be
+# dropped. To rotate it:
+#   1. Generate a new token at https://sonarcloud.io/account/security
+#      (type: Project Analysis Token, project: manugarg_pacparser, max expiry).
+#   2. Update the repo secret:
+#        gh secret set SONAR_TOKEN --repo manugarg/pacparser
+#      (or GitHub UI: Settings > Secrets and variables > Actions > SONAR_TOKEN)
+#   3. Re-run this workflow (or push) to confirm the analysis passes.
 name: SonarCloud
 on:
   push:


### PR DESCRIPTION
## Summary
- Add a comment header to `sonar.yml` with steps to rotate the expiring `SONAR_TOKEN` secret.

The token expires (~1 year max on SonarCloud) and this repo changes rarely, so it lapses unnoticed and breaks the next run. The steps live where you land when the check fails. No behavior change.