### PR TITLE
fix: link pthread into pacparser for glibc < 2.34

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -92,7 +92,7 @@ pacparser.o: pacparser.c pac_utils.h pacparser.h
 	touch pymod/pacparser_o_buildstamp
 
 $(LIBRARY): pacparser.o quickjs/libquickjs.a
-	$(MKSHLIB) $(MAINT_CFLAGS) $(CFLAGS) $(LDFLAGS) $(LIB_OPTS) -o $(LIBRARY) pacparser.o quickjs/libquickjs.a -lm
+	$(MKSHLIB) $(MAINT_CFLAGS) $(CFLAGS) $(LDFLAGS) $(LIB_OPTS) -o $(LIBRARY) pacparser.o quickjs/libquickjs.a -lm -lpthread
 
 libpacparser.a: pacparser.o quickjs/libquickjs.a
 	cp quickjs/libquickjs.a libpacparser.a
@@ -102,7 +102,7 @@ $(LIBRARY_LINK): $(LIBRARY)
 	ln -sf $(LIBRARY) $(LIBRARY_LINK)
 
 pactester: pactester.c pacparser.h libpacparser.a
-	$(CC) $(MAINT_CFLAGS) $(CFLAGS) $(LDFLAGS) pactester.c libpacparser.a -o pactester -lm -L. -I.
+	$(CC) $(MAINT_CFLAGS) $(CFLAGS) $(LDFLAGS) pactester.c libpacparser.a -o pactester -lm -lpthread -L. -I.
 
 testpactester: pactester $(LIBRARY_LINK)
 	echo "Running tests for pactester."

--- a/src/pymod/setup.py
+++ b/src/pymod/setup.py
@@ -239,7 +239,7 @@ def main(patched_func):
 
     extra_objects = list(found_objects.values())
 
-    libraries = []
+    libraries = ["pthread"]
     extra_link_args = []
 
     if sys.platform == "win32":


### PR DESCRIPTION
This is needed since moving to quickjs-ng if building for older glibc versions.